### PR TITLE
Add openrouter to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -68,6 +68,7 @@ js_cdns:
 # AI/ML Services
 ai_services:
   - api.anthropic.com
+  - openrouter.ai
 
 # Docker Registries and Container Services
 docker_registries:


### PR DESCRIPTION
Add openrouter to whitelist so its accessible within the sandbox. This is to fix `ECONRESET` errors while trying to hit `https://openrouter.ai/api/v1/chat/completions`