### PR TITLE
Add Anthropic, OpenAI, and Gemini domains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -67,8 +67,20 @@ js_cdns:
 
 # AI/ML Services
 ai_services:
+  # Anthropic (Core API & Console)
+  - console.anthropic.com
   - api.anthropic.com
+  - claude.ai
+  # OpenAI (Core API, ChatGPT & Codex)
   - api.openai.com
+  - platform.openai.com
+  - chatgpt.com
+  - openai.com
+  # Google Gemini (Core API & Web)
+  - generativelanguage.googleapis.com
+  - gemini.google.com
+  - aistudio.google.com
+  # Other AI/ML providers
   - api.perplexity.ai
   - api.deepseek.com
   - api.groq.com


### PR DESCRIPTION
## Summary
- add Anthropic, OpenAI, and Google Gemini domains to ai_services with grouping comments

## Testing
- not applicable