### PR TITLE
feat: add Alibaba Qwen AI and Google Gemini/AI Studio domains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -74,6 +74,11 @@ ai_services:
   - api.groq.com
   - api.expo.dev
   - openrouter.ai
+  - chat.qwen.ai
+  - dashscope.aliyuncs.com
+  - dashscope-intl.aliyuncs.com
+  - generativelanguage.googleapis.com
+  - ai.google.dev
 
 # Docker Registries and Container Services
 docker_registries:


### PR DESCRIPTION
## Summary
Add the following AI service domains to the whitelist:

- `chat.qwen.ai` - Alibaba's Qwen AI
- `dashscope.aliyuncs.com` - Alibaba Cloud AI
- `dashscope-intl.aliyuncs.com` - Alibaba Cloud AI International
- `generativelanguage.googleapis.com` - Google Gemini API
- `ai.google.dev` - Google AI Studio

## Reason
These additions address user-reported needs for accessing Chinese AI providers (Alibaba Qwen) and Google's AI services from Daytona sandboxes.