### PR TITLE
feat: add models.dev to allowed domains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -88,6 +88,7 @@ ai_services:
   - dashscope-intl.aliyuncs.com
   - generativelanguage.googleapis.com
   - ai.google.dev
+  - models.dev
 
 # Docker Registries and Container Services
 docker_registries:


### PR DESCRIPTION
Models.dev is used by [OpenCode](https://opencode.ai/).

This should fix https://github.com/daytonaio/daytona/issues/3295