### PR TITLE
feat: add api.letta.com to allowed domains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -80,6 +80,7 @@ ai_services:
   - dashscope-intl.aliyuncs.com
   - ai.google.dev
   - models.dev
+  - api.letta.com
 
 # Docker Registries and Container Services
 docker_registries:


### PR DESCRIPTION
This allows #3349 to work for all Daytona accounts.