### PR TITLE
chore: add r2

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -60,6 +60,7 @@ debian_repos:
 cdn_services:
   - fastly.com
   - cloudflare.com
+  - r2.cloudflarestorage.com
   - "*.r2.cloudflarestorage.com"
 
 js_cdns:


### PR DESCRIPTION
Need to load objects (ex. xlsx files) from r2 into the sandbox. 

![S__117563407](https://github.com/user-attachments/assets/db1bc2bb-cb78-468f-959d-cbe3c00ed4de)
