### PR TITLE
feat: claude and messaging channels domains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -146,3 +146,9 @@ netbird:
 # Daytona
 daytona:
   - app.daytona.io
+
+# Messaging Platforms
+messaging_services:
+  - api.telegram.org
+  - web.whatsapp.com
+  - "*.whatsapp.net"


### PR DESCRIPTION
This PR adds the domain allowlist required to run Claude and Moltbot inside the Daytona sandbox.

Moltbot itself does not require any domain whitelisting to operate. However, to enable integration with external channels such as Telegram and WhatsApp described inside our guide, their respective domains must be whitelisted.