### PR TITLE
Add Azure DevOps domains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -40,15 +40,11 @@ bitbucket:
   - bitbucket.org
 
 azure_devops:
-  # Git HTTPS
   - dev.azure.com
   - "*.dev.azure.com"
-  # Auth
   - login.microsoftonline.com
-  # Legacy
   - visualstudio.com
   - "*.visualstudio.com"
-  # SSH
   - ssh.dev.azure.com
   - vs-ssh.visualstudio.com
 


### PR DESCRIPTION
## Summary
- Add Azure DevOps domains to enable Git operations (clone, pull, push) with Azure Repos

## Domains Added

| Domain | Purpose |
|--------|---------|
| `dev.azure.com` | Main HTTPS endpoint |
| `*.dev.azure.com` | Org-specific URLs (`{org}.dev.azure.com`) |
| `login.microsoftonline.com` | Microsoft Entra ID (OAuth) authentication |
| `visualstudio.com` | Legacy domain |
| `*.visualstudio.com` | Legacy org-specific URLs (`{org}.visualstudio.com`) |
| `ssh.dev.azure.com` | SSH endpoint |
| `vs-ssh.visualstudio.com` | Legacy SSH endpoint |

## References
- [Azure DevOps: Allowed IPs & URLs](https://learn.microsoft.com/en-us/azure/devops/organizations/security/allow-list-ip-url)
- [Azure DevOps domains overview](https://jessehouwing.net/azure-devops-what-domains-are-used-by-your-account/)
- [Git Credential Manager: Azure Repos](https://github.com/git-ecosystem/git-credential-manager/blob/main/docs/azrepos-users-and-tokens.md)