### PR TITLE
Add Zhipu AI domains(cn and internation) to the ai_services section

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -96,6 +96,8 @@ ai_services:
   - opencode.ai
   - "*.opencode.ai"
   - api.letta.com
+  - open.bigmodel.cn
+  - api.z.ai
 
 # Docker Registries and Container Services
 docker_registries:


### PR DESCRIPTION
## Summary
- Add `open.bigmodel.cn` - Zhipu AI China API endpoint
- Add `api.z.ai` - Zhipu AI international API endpoint                                                                           
                                                                                                                                   
## Details                                                                                                                       
These domains are official endpoints for Zhipu AI's GLM models API service.