### PR TITLE
Add LLM observability domains (Langfuse)

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -152,3 +152,8 @@ messaging_services:
   - api.telegram.org
   - web.whatsapp.com
   - "*.whatsapp.net"
+
+# LLM observability / tracing
+llm_observability:
+  - "*.langfuse.com"
+  - "*.cloud.langfuse.com"


### PR DESCRIPTION
Adds `*.langfuse.com` and `*.cloud.langfuse.com` under `llm_observability` for Langfuse tracing/observability.