### PR TITLE
feat(ai): add vercel ai gateway to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -108,6 +108,7 @@ ai_services:
   - api.fireworks.ai
   - open.bigmodel.cn
   - api.z.ai
+  - ai-gateway.vercel.sh
 
 # Docker Registries and Container Services
 docker_registries:


### PR DESCRIPTION
adds ai-gateway.vercel.sh to ai_services. tools like claude code and opencode use vercel ai gateway as their api proxy for model providers.