### PR TITLE
add playwright to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -159,3 +159,8 @@ messaging_services:
 llm_observability:
   - "*.langfuse.com"
   - "*.cloud.langfuse.com"
+
+# Playwright Browser Downloads
+playwright:
+  - playwright.dev
+  - cdn.playwright.dev


### PR DESCRIPTION
## Summary
Add `playwright.dev` and `cdn.playwright.dev` to a new Playwright section in `whitelist.yaml`.

Playwright is an open-source end-to-end testing framework by Microsoft for web applications. It supports Chromium, Firefox, and WebKit browsers. The CDN domain is needed to download browser binaries. [playwright.dev](https://playwright.dev)

## Test plan
- [x] Verified `whitelist.yaml` is valid YAML after the edit
- [x] Domains follow the existing pattern for dev tools