### PR TITLE
feat: add Clerk accounts domain to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -179,6 +179,10 @@ clerk:
   - "*.clerk.com"
   - clerk.dev
   - "*.clerk.dev"
+  - accounts.dev
+  - "*.accounts.dev"
+  - clerk.accounts.dev
+  - "*.clerk.accounts.dev"
   
 # Vercel (deployments, preview URLs, Next.js telemetry)
 vercel:


### PR DESCRIPTION
## Summary
- Adds  `accounts.dev`,  `*.accounts.dev`, `clerk.accounts.dev` and `*.clerk.accounts.dev` to the Clerk authentication section
- This covers Clerk Frontend API URLs (e.g. `<slug>.clerk.accounts.dev` and `<slug>.accounts.dev`)

## Test plan
- [x] Verify wildcard `*.clerk.accounts.dev` `*.accounts.dev` matches Clerk Frontend API subdomains
- [x] Confirm existing Clerk domains are unchanged