### PR TITLE
feat: add ClickUp project management domains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -209,6 +209,11 @@ figma:
   - "*.figma.com"
   - "*.figmafiles.com"
   
+# ClickUp (Project Management API + MCP)
+clickup:
+  - clickup.com
+  - "*.clickup.com"
+
 # Playwright Browser Downloads
 playwright:
   - playwright.dev


### PR DESCRIPTION
## Summary
- Adds `clickup.com` and `*.clickup.com` to whitelist for ClickUp project management
- Covers API (`api.clickup.com`), MCP server (`mcp.clickup.com`), attachments, and OAuth flows

## Test plan
- [ ] Verify `*.clickup.com` matches ClickUp API and MCP subdomains
- [ ] Confirm no conflicts with existing whitelist entries