### PR TITLE
Add herokuapp domains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -157,6 +157,11 @@ convex:
   - "*.convex.cloud"
   - "*.convex.site"
 
+# Heroku
+heroku:
+  - "herokuapp.com"
+  - "*.herokuapp.com"
+
 # Messaging Platforms
 messaging_services:
   - api.telegram.org


### PR DESCRIPTION
Summary
Adds herokuapp.com and *.herokuapp.com to the whitelist
This covers Heroku app URLs (e.g. <app>.herokuapp.com)
Test plan
Verify wildcard *.herokuapp.com matches Heroku app subdomains
Confirm existing whitelist domains are unchanged