### PR TITLE
Add Rust and Go package manager domains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -56,6 +56,24 @@ pypi:
   - bootstrap.pypa.io
   - astral.sh
 
+# Rust Package Manager and Toolchain
+rust:
+  - crates.io
+  - static.crates.io
+  - index.crates.io
+  - static.rust-lang.org
+  - rustup.rs
+  - doc.rust-lang.org
+
+# Go Module Proxy and Toolchain
+golang:
+  - proxy.golang.org
+  - sum.golang.org
+  - index.golang.org
+  - go.dev
+  - "*.golang.org"
+  - storage.googleapis.com
+
 # PHP/Composer Package Manager
 composer_packages:
   - "*.packagist.org"


### PR DESCRIPTION
- Add Rust toolchain and package manager domains (crates.io, static.rust-lang.org, rustup.rs)
- Add Go module proxy and toolchain domains (proxy.golang.org, sum.golang.org, go.dev)
