### PR TITLE
Add *.z.ai and *.moonshot.ai to AI services whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -107,7 +107,8 @@ ai_services:
   - api.letta.com
   - api.fireworks.ai
   - open.bigmodel.cn
-  - api.z.ai
+  - "*.z.ai"
+  - "*.moonshot.ai"
   - ai-gateway.vercel.sh
 
 # Docker Registries and Container Services


### PR DESCRIPTION
## Summary
- Replace `api.z.ai` with `*.z.ai` to cover all subdomains (the existing `api.z.ai` entry is subsumed by the wildcard)
- Add `*.moonshot.ai` for Kimi/Moonshot AI API access

Both are AI/ML API providers used in development workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)