### PR TITLE
Add bare packagist.org domain for Composer metadata

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -58,6 +58,7 @@ pypi:
 
 # PHP/Composer Package Manager
 composer_packages:
+  - packagist.org
   - "*.packagist.org"
   - packagist.com
 


### PR DESCRIPTION
## Summary
- Adds the bare `packagist.org` domain to the `composer_packages` whitelist

## Reason
Composer requires access to the bare `packagist.org` domain for metadata lookups 
in addition to the existing `*.packagist.org` wildcard (which covers subdomains 
like `repo.packagist.org`).

Without this, Composer dependency resolution fails when trying to fetch package 
metadata from the root domain.