### PR TITLE
Add ElevenLabs and Autumn API domains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -110,6 +110,7 @@ ai_services:
   - "*.z.ai"
   - "*.moonshot.ai"
   - ai-gateway.vercel.sh
+  - api.elevenlabs.io
 
 # Docker Registries and Container Services
 docker_registries:
@@ -237,6 +238,10 @@ supabase:
 clickup:
   - clickup.com
   - "*.clickup.com"
+
+# Autumn (Billing API)
+autumn:
+  - api.useautumn.com
 
 # Playwright Browser Downloads
 playwright:


### PR DESCRIPTION
## Summary
- add `api.elevenlabs.io` to `ai_services` for ElevenLabs API access
- add an `autumn` section with `api.useautumn.com` for Autumn API access
