### PR TITLE
feat: GCS endpoint

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -147,6 +147,10 @@ aws_s3_endpoints:
   - s3.eu-west-1.amazonaws.com
   - s3.eu-west-2.amazonaws.com
 
+# Google Cloud Storage endpoints
+gcs:
+  - storage.googleapis.com
+
 # Daytona
 daytona:
   - app.daytona.io


### PR DESCRIPTION
Added a GCS whitelist section with `storage.googleapis.com` so GCS mounting is allowed in the sandbox.