### PR TITLE
feat: add Sanity CMS API domains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -297,3 +297,10 @@ playwright:
 doppler:
   - doppler.com
   - "*.doppler.com"
+
+# Sanity (CMS API)
+sanity:
+  - "*.sanity.io"
+  - "*.sanity.work"
+  - sanity.io
+  - sanity.work


### PR DESCRIPTION
Adds Sanity (CMS API) domains to the whitelist:

- `*.sanity.io` - API, CDN, and Studio subdomains
- `*.sanity.work` - Internal staging subdomains
- `sanity.io` - Main domain
- `sanity.work` - Internal staging domain