### PR TITLE
Add *.cursor.sh to AI/ML services allowlist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -123,6 +123,7 @@ ai_services:
   - ai.google.dev
   - models.dev
   - "*.cursor.com"
+  - "*.cursor.sh"
   - opencode.ai
   - "*.opencode.ai"
   - api.letta.com


### PR DESCRIPTION
The Cursor CLI (agent) connects to api2.cursor.sh and repo42.cursor.sh for API access. The current allowlist includes *.cursor.com but the CLI uses the cursor.sh domain. This prevents the Cursor CLI from functioning in Tier 1/2 sandboxes.

Hostnames needed: api2.cursor.sh, repo42.cursor.sh, staging.cursor.sh

Adding *.cursor.sh to match the existing *.cursor.com entry.