### PR TITLE
Add Shopify Domains for Development

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -123,6 +123,7 @@ ai_services:
   - ai.google.dev
   - models.dev
   - "*.cursor.com"
+  - "*.cursor.sh"
   - opencode.ai
   - "*.opencode.ai"
   - api.letta.com

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -306,3 +306,20 @@ playwright:
 doppler:
   - doppler.com
   - "*.doppler.com"
+
+# Sanity (CMS API)
+sanity:
+  - "*.sanity.io"
+  - "*.sanity.work"
+  - sanity.io
+  - sanity.work
+
+# Shopify (Development)
+shopify:
+  - shopify.com
+  - "*.shopify.com"
+  - "*.myshopify.com"
+  - "*.shopify.dev"
+  - "*.shopifycdn.com"
+  - "*.trycloudflare.com"
+  - "*.cfargotunnel.com"

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -172,15 +172,15 @@ google_fonts:
   - fonts.googleapis.com
   - fonts.gstatic.com
 
-# AWS S3 endpoints
-aws_s3_endpoints:
-  - s3.us-east-1.amazonaws.com
-  - s3.us-east-2.amazonaws.com
-  - s3.us-west-1.amazonaws.com
-  - s3.us-west-2.amazonaws.com
-  - s3.eu-central-1.amazonaws.com
-  - s3.eu-west-1.amazonaws.com
-  - s3.eu-west-2.amazonaws.com
+# AWS endpoints
+aws:
+  - "*.us-east-1.amazonaws.com"
+  - "*.us-east-2.amazonaws.com"
+  - "*.us-west-1.amazonaws.com"
+  - "*.us-west-2.amazonaws.com"
+  - "*.eu-central-1.amazonaws.com"
+  - "*.eu-west-1.amazonaws.com"
+  - "*.eu-west-2.amazonaws.com"
 
 # Google Cloud Storage endpoints
 gcs:


### PR DESCRIPTION
Adds outbound whitelist for:

- shopify.com
- "*.shopify.com"
- "*.myshopify.com"
- "*.shopify.dev"
- "*.shopifycdn.com"
- "*.trycloudflare.com"
- "*.cfargotunnel.com"

Fixes sandbox connectivity for Shopify app development.