### PR TITLE
Added domains required for shopify development

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -314,3 +314,13 @@ sanity:
   - "*.sanity.work"
   - sanity.io
   - sanity.work
+
+# Shopify (Development)
+shopify:
+  - shopify.com
+  - "*.shopify.com"
+  - "*.myshopify.com"
+  - "*.shopify.dev"
+  - "*.shopifycdn.com"
+  - "*.trycloudflare.com"
+  - "*.cfargotunnel.com"


### PR DESCRIPTION
Adds outbound whitelist for:

- shopify.com
- "*.shopify.com"
- "*.myshopify.com"
- "*.shopify.dev"
- "*.shopifycdn.com"
- "*.trycloudflare.com"
- "*.cfargotunnel.com"

Fixes sandbox connectivity for Shopify app development.