### PR TITLE
Add Shortcut (api.app.shortcut.com) to the whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -327,3 +327,8 @@ shopify:
 
 mesa:
   - "*.mesa.dev"
+
+# Shortcut (Ticket system API + MCP)
+shortcut:
+  - api.app.shortcut.com
+  - app.shortcut.com


### PR DESCRIPTION
Adds Shortcut (ticket system API + web app) to the outbound whitelist.

**Why:** Coding agents running in Daytona sandboxes frequently need to read/write Shortcut stories. Currently outbound to `api.app.shortcut.com` RSTs on Tier 1/2 sandboxes, so agents have to proxy Shortcut calls through an external orchestrator instead of hitting the API directly.

**Evidence:** Confirmed from inside a Daytona sandbox using `curl -o /dev/null -w '%{http_code}'`:
- `https://api.github.com/` → `200` in under 50 ms (allowed)
- `https://api.app.shortcut.com/` → `000` with "Connection reset by peer" (blocked)

**Hosts being added:**
- `api.app.shortcut.com` — REST API (`/api/v3/...`)
- `app.shortcut.com` — web app; hit by some Shortcut MCP servers and OAuth flows