### PR TITLE
Add RubyGems (rubygems.org) to the whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -327,3 +327,8 @@ shopify:
 
 mesa:
   - "*.mesa.dev"
+
+# RubyGems (Ruby gem metadata + gem tarball CDN)
+rubygems:
+  - rubygems.org
+  - index.rubygems.org


### PR DESCRIPTION
## What

Adds a new `rubygems` group with the two hosts Ruby developers need for `bundle install` / `gem install`:

```yaml
rubygems:
  - rubygems.org
  - index.rubygems.org
```

- `rubygems.org` — gem metadata / API host
- `index.rubygems.org` — CDN where `bundler` / `gem install` fetches the actual `.gem` tarballs (both are required; blocking either breaks installs)

## Why

Ruby developers routinely need to run `bundle install` inside Daytona sandboxes — during image bakes, during agent-driven task execution, and during interactive dev work.

Currently both hosts are blocked on Tier 1/2. I empirically confirmed `Connection reset by peer` to `rubygems.org` and `index.rubygems.org` from inside a sandbox, while `api.github.com` returned 200 from the same shell. Adding these two hosts unblocks a large class of Ruby workflows.

## DCO

Commit is signed off (`git commit -s`) — `Signed-off-by:` trailer is present.