### PR TITLE
Add Hex.pm (repo.hex.pm, builds.hex.pm) to the whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -327,3 +327,8 @@ shopify:
 
 mesa:
   - "*.mesa.dev"
+
+# Hex.pm (Elixir/Erlang package registry)
+elixir:
+  - repo.hex.pm
+  - builds.hex.pm


### PR DESCRIPTION
This allows Elixir programs to work properly by allowing Mix to fetch packages from the official registry.