### PR TITLE
feat: add USAspending.gov domains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -327,3 +327,8 @@ shopify:
 
 mesa:
   - "*.mesa.dev"
+
+# USAspending.gov (federal spending data API + bulk downloads)
+usaspending:
+  - api.usaspending.gov
+  - files.usaspending.gov


### PR DESCRIPTION
Adds outbound whitelist for:

- api.usaspending.gov
- files.usaspending.gov

Needed to run the NASA federal-spending text-to-SQL demo in [openai-agents-python](https://github.com/openai/openai-agents-python) (`examples/sandbox/extensions/daytona/usaspending_text2sql`). On first start the sandbox downloads FY2021–FY2025 NASA spending data from USAspending.gov: `api.usaspending.gov` hosts the bulk download API and glossary endpoints, and the generated zip is served from `files.usaspending.gov`.