### PR TITLE
feat: add trynia.ai to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -138,6 +138,8 @@ ai_services:
   - "*.ampcode.com"
   - "*.openai.azure.com"
   - "*.services.ai.azure.com"
+  - trynia.ai
+  - "*.trynia.ai"
 
 # Hugging Face (Model Hub + Datasets + Inference API)
 huggingface:


### PR DESCRIPTION
Adds `trynia.ai` and `*.trynia.ai` to the `ai_services` whitelist section.