### PR TITLE
feat: add *.astral.sh wildcard to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -55,6 +55,7 @@ pypi:
   - files.pythonhosted.org
   - bootstrap.pypa.io
   - astral.sh
+  - "*.astral.sh"
 
 # Rust Package Manager and Toolchain
 rust:


### PR DESCRIPTION
astral.sh's installer URL (e.g. `https://astral.sh/uv/<ver>/install.sh`) 301s to releases.astral.sh. With only the apex `astral.sh` whitelisted, curl following the redirect opens a new TLS connection with SNI=releases.astral.sh which doesn't match any filter chain → blackhole → `curl: (35) Connection reset by peer`.

Adding `*.astral.sh` to resolve this.

## Repro (any Tier 1/2 sandbox)

```
apt-get update && apt-get install -y curl
curl -LsSf https://astral.sh/uv/0.9.5/install.sh | sh
# → curl: (35) Recv failure: Connection reset by peer
```
(The above is on debian:bookworm-slim with curl 7.88; on debian:bullseye-slim with curl 7.74, the same RST is reported as `curl: (35) OpenSSL SSL_connect: Connection reset by peer in connection to releases.astral.sh:443`.)

Works on Tier 3/4 (no egress filter) and outside Daytona.