### PR TITLE
Whitelist AWS ap-south-1 endpoints

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -184,6 +184,7 @@ aws:
   - "*.eu-central-1.amazonaws.com"
   - "*.eu-west-1.amazonaws.com"
   - "*.eu-west-2.amazonaws.com"
+  - "*.ap-south-1.amazonaws.com"
 
 # Google Cloud Storage endpoints
 gcs:


### PR DESCRIPTION
Allow outbound traffic to AWS Mumbai (ap-south-1) by adding *.ap-south-1.amazonaws.com to the Envoy whitelist so SDKs and tools can reach regional endpoints (S3, DynamoDB, etc.) in that region.