### PR TITLE
Add *.claude.ai wildcard to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -105,6 +105,7 @@ js_cdns:
 ai_services:
   - "*.anthropic.com"
   - claude.ai
+  - "*.claude.ai"
   - platform.claude.com
   - openai.com
   - "*.openai.com"


### PR DESCRIPTION
The Claude Code installer at https://claude.ai/install.sh 302-redirects to https://downloads.claude.ai/claude-code-releases/bootstrap.sh, which was being blocked. Wildcard covers downloads.claude.ai and any future sibling subdomains.