### PR TITLE
Add installer endpoints used by harbor agents and benchmarks

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -13,6 +13,7 @@ npm_registry:
   - registry.npmjs.com
   - nodejs.org
   - nodesource.com
+  - deb.nodesource.com
   - npm.pkg.github.com
 
 yarn_packages:
@@ -30,6 +31,7 @@ github:
   - github.com
   - "*.github.com"
   - "*.githubusercontent.com"
+  - gh.io
   - ghcr.io
 
 gitlab:
@@ -57,6 +59,10 @@ pypi:
   - astral.sh
   - "*.astral.sh"
 
+# Anaconda / Conda (Python distribution + package channels)
+conda:
+  - repo.anaconda.com
+
 # Rust Package Manager and Toolchain
 rust:
   - crates.io
@@ -64,6 +70,7 @@ rust:
   - index.crates.io
   - static.rust-lang.org
   - rustup.rs
+  - sh.rustup.rs
   - doc.rust-lang.org
 
 # Go Module Proxy and Toolchain
@@ -72,8 +79,13 @@ golang:
   - sum.golang.org
   - index.golang.org
   - go.dev
+  - golang.org
   - "*.golang.org"
   - storage.googleapis.com
+
+# C/C++ Build Tools
+build_tools:
+  - cmake.org
 
 # PHP/Composer Package Manager
 composer_packages:
@@ -124,10 +136,12 @@ ai_services:
   - dashscope-intl.aliyuncs.com
   - ai.google.dev
   - models.dev
+  - cursor.com
   - "*.cursor.com"
   - "*.cursor.sh"
   - opencode.ai
   - "*.opencode.ai"
+  - aider.chat
   - api.letta.com
   - api.fireworks.ai
   - open.bigmodel.cn
@@ -191,6 +205,10 @@ aws:
 # Google Cloud Storage endpoints
 gcs:
   - storage.googleapis.com
+
+# Google general downloads (Chrome, gcloud SDK, Android tools, Go binaries via golang.org redirect, etc.)
+google_downloads:
+  - dl.google.com
 
 # Google Cloud apt package registry (gcsfuse, google-cloud-sdk, kubectl, etc.)
 google_package_registry:
@@ -301,6 +319,10 @@ supabase:
 clickup:
   - clickup.com
   - "*.clickup.com"
+
+# Atlassian (acli installer — GPG key + apt repo)
+atlassian:
+  - acli.atlassian.com
 
 # Railway (Deployments)
 railway:


### PR DESCRIPTION
Searched [harbor](https://github.com/harbor-framework/harbor)'s source for sandbox-side `curl`/`wget` endpoints; ten hosts referenced from agent installers and adapter Dockerfiles aren't currently whitelisted, so each RSTs on Tier 1/2 (`curl: (35) Connection reset by peer`).

## Agent installers

| domain | used by |
|---|---|
| `aider.chat` | aider |
| `cursor.com` | cursor-cli (apex; `*.cursor.com` already there) |
| `gh.io` | github copilot-cli (URL shortener → `raw.githubusercontent.com`, target already covered) |
| `acli.atlassian.com` | rovodev-cli (GPG key + apt repo) |

## Adapter Dockerfiles

| domain | used by |
|---|---|
| `deb.nodesource.com` | adebench, aider_polyglot, ds1000 (apex `nodesource.com` already there) |
| `golang.org` | aider_polyglot (apex; `*.golang.org` already there) |
| `dl.google.com` | aider_polyglot (302 target of `golang.org/dl/...`) |
| `sh.rustup.rs` | aider_polyglot (apex `rustup.rs` already there) |
| `cmake.org` | featbench |
| `repo.anaconda.com` | scienceagentbench, replicationbench (Miniconda installer) |

## Repro

In a `debian:bookworm-slim` Tier 1/2 sandbox:

```
apt-get update && apt-get install -y curl
curl -fsSL https://<host>/<path> -o /dev/null
# → curl: (35) Recv failure: Connection reset by peer
```

All ten verified failing on 2026-04-29; same URLs work on Tier 3/4.