### PR TITLE
add Kimi coding plan endpoint

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -147,6 +147,7 @@ ai_services:
   - open.bigmodel.cn
   - "*.z.ai"
   - "*.moonshot.ai"
+  - "*.kimi.com"
   - ai-gateway.vercel.sh
   - api.elevenlabs.io
   - api.featherless.ai


### PR DESCRIPTION
Moonshot switched most of their platform from platform.moonshot.ai to platform.kimi.com (as well as api.kimi.com)
