### PR TITLE
Whitelist GCP domains (accounts, googleapis, gstatic)

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -206,6 +206,12 @@ aws:
 gcs:
   - storage.googleapis.com
 
+# Google Cloud Platform (OAuth + APIs + static assets)
+gcp:
+  - accounts.google.com
+  - "*.googleapis.com"
+  - "*.gstatic.com"
+
 # Google general downloads (Chrome, gcloud SDK, Android tools, Go binaries via golang.org redirect, etc.)
 google_downloads:
   - dl.google.com

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -81,7 +81,6 @@ golang:
   - go.dev
   - golang.org
   - "*.golang.org"
-  - storage.googleapis.com
 
 # C/C++ Build Tools
 build_tools:
@@ -201,10 +200,6 @@ aws:
   - "*.eu-west-1.amazonaws.com"
   - "*.eu-west-2.amazonaws.com"
   - "*.ap-south-1.amazonaws.com"
-
-# Google Cloud Storage endpoints
-gcs:
-  - storage.googleapis.com
 
 # Google Cloud Platform (OAuth + APIs + static assets)
 gcp:

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -205,6 +205,7 @@ aws:
 gcp:
   - accounts.google.com
   - "*.googleapis.com"
+  - "*.storage.googleapis.com"
   - "*.gstatic.com"
 
 # Google general downloads (Chrome, gcloud SDK, Android tools, Go binaries via golang.org redirect, etc.)


### PR DESCRIPTION
Extend the allowlist with a gcp section so sandboxes can reach Google sign-in (accounts.google.com), Google APIs (*.googleapis.com), and Google static assets (*.gstatic.com) for typical GCP / Google Cloud client flows.