### PR TITLE
Add '*.minimax.io' to the whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -147,6 +147,7 @@ ai_services:
   - open.bigmodel.cn
   - "*.z.ai"
   - "*.moonshot.ai"
+  - "*.minimax.io"
   - ai-gateway.vercel.sh
   - api.elevenlabs.io
   - api.featherless.ai


### PR DESCRIPTION
Add the Minimax domain to support development using the Minimax model.