### PR TITLE
Add Cloudflare Tunnel egress hostnames to the whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -114,6 +114,10 @@ js_cdns:
   - unpkg.com
   - jsdelivr.net
 
+cloudflare_tunnel:
+  - "*.argotunnel.com"
+  - "*.v2.argotunnel.com"
+
 # AI/ML Services
 ai_services:
   - "*.anthropic.com"


### PR DESCRIPTION
Adds outbound whitelist for:

- *.argotunnel.com
- *.v2.argotunnel.com

Fixes sandbox connectivity for Cloudflare Tunnel. cloudflared dials regionN.v2.argotunnel.com on TCP/UDP 7844 to register the tunnel. Placed in a new cloudflare_tunnel: section.