### PR TITLE
add: adding auth0 endpoints for authentication whitelisting

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -345,6 +345,11 @@ doppler:
   - doppler.com
   - "*.doppler.com"
 
+# Auth0 (Authentication)
+auth0:
+  - auth0.com
+  - "*.auth0.com"
+
 # Sanity (CMS API)
 sanity:
   - "*.sanity.io"


### PR DESCRIPTION
Adds "*.auth0.com" endpoints for authentication based workloads within sandboxes. Includes the base domain 'auth0.com'.