### PR TITLE
Add Fly.io to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -331,6 +331,12 @@ railway:
   - railway.com
   - "*.railway.com"
   
+# Fly.io (Deployments + GA Anycast endpoints)
+fly:
+  - fly.io
+  - "*.fly.dev"
+  - api.fly.io
+
 # Autumn (Billing API)
 autumn:
   - api.useautumn.com


### PR DESCRIPTION
## Summary

Adds Fly.io to the Envoy proxy whitelist so sandboxes can reach apps deployed on Fly.io's public anycast edge.

## Domains added

- `fly.io`
- `*.fly.dev` — covers Fly's default app hostnames (e.g. `<app>.fly.dev`)
- `api.fly.io` — Fly's machines/control-plane API, useful for agents that manage Fly deployments

## Why

We're integrating Daytona-hosted agents with our MCP server at `nulegal-mcp.fly.dev` (an MCP-over-SSE endpoint). Today the agent gets `Connection reset by peer` on TLS handshake from inside the sandbox because `*.fly.dev` isn't in the default Envoy allowlist. Other major PaaS endpoints (`*.vercel.app`, `*.railway.app`, `*.herokuapp.com`, `*.run.app` notably missing) are present, so this fills a gap that's likely affecting other Daytona users running agent infra on Fly.

Format follows PR #59 (Railway) and PR #89 (Cloudflare Tunnel).

## Verification

The Envoy single-level wildcard rule means `*.fly.dev` matches `nulegal-mcp.fly.dev` (and any one-level Fly app hostname) but not deeper subdomains, which is the standard Daytona pattern.