### PR TITLE
Add *.copass.id to AI services whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -166,6 +166,8 @@ ai_services:
   - trynia.ai
   - "*.trynia.ai"
   - api.x.ai
+  - copass.id
+  - "*.copass.id"
 
 # Hugging Face (Model Hub + Datasets + Inference API)
 huggingface:


### PR DESCRIPTION
## Summary

Adds `*.copass.id` so sandboxed agents can forward chat-completion traffic to the [Copass](https://copass.com) LLM gateway.

## Why

Copass operates an OpenAI-compatible LLM gateway. Our agent runtime spins up per-tenant Daytona sandboxes that run an OpenAI-compatible inference server (Hermes by Nous Research). The server is configured to forward `/v1/chat/completions` to the Copass managed gateway, which:

- validates a per-sandbox HS256 JWT (minted on the API host, dies with the sandbox)
- enforces a per-user credit balance floor before forwarding
- records a usage deduction post-stream
- forwards to the upstream provider with the real provider key (which never enters the sandbox env)

Without an allowlist entry, requests from inside the sandbox fail with TLS-handshake `Connection reset by peer` at the Envoy proxy — verified by `curl -v` from a live sandbox.

## Wildcard scope

`*.copass.id` matches one subdomain level (per the file's documented wildcard semantics) — covers regional/environment subdomains.