### PR TITLE
add api.x.ai to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -156,6 +156,7 @@ ai_services:
   - "*.services.ai.azure.com"
   - trynia.ai
   - "*.trynia.ai"
+  - api.x.ai
 
 # Hugging Face (Model Hub + Datasets + Inference API)
 huggingface:


### PR DESCRIPTION
add api.x.ai to whitelist to allow sandbox to call xAI's Grok models