### PR TITLE
Add zenmux.ai to AI services whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -166,6 +166,7 @@ ai_services:
   - trynia.ai
   - "*.trynia.ai"
   - api.x.ai
+  - zenmux.ai
 
 # Hugging Face (Model Hub + Datasets + Inference API)
 huggingface:


### PR DESCRIPTION
## Summary

Adds `zenmux.ai` to the AI/ML services whitelist.

## Context

Zenmux provides an OpenAI-compatible LLM API endpoint at `https://zenmux.ai/api/v1`. This is needed for Daytona Tier 1 sandbox evaluations where the agent runtime calls the model provider from inside the sandbox.

## Validation

- Parsed `whitelist.yaml` with Python/YAML successfully.
- Confirmed the diff is a single domain addition.

Relates to #96