### PR TITLE
Add Axiom and Grafana Cloud to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -402,3 +402,16 @@ shortcut:
 usaspending:
   - api.usaspending.gov
   - files.usaspending.gov
+
+# Axiom (Observability — logs, traces, APL queries)
+axiom:
+  - api.axiom.co
+  - api.eu.axiom.co
+  - cdn.axiom.co
+  - "*.axiom.co"
+
+# Grafana Cloud (Observability — metrics, logs, traces dashboards)
+grafana:
+  - grafana.com
+  - "*.grafana.com"
+  - "*.grafana.net"


### PR DESCRIPTION
## Summary

Adds two widely-used observability platforms to the org allowlist:

- **Axiom** (logs / traces / APL queries) — `api.axiom.co`, `api.eu.axiom.co`, `cdn.axiom.co`, `*.axiom.co`
- **Grafana Cloud** (metrics / logs / traces dashboards) — `grafana.com`, `*.grafana.com`, `*.grafana.net`

## Motivation

Both are commonly reached for from on-call / customer-support workflows running inside Daytona sandboxes, alongside already-allowlisted Sentry. Without them, the official CLIs (\`axiom\`, \`grafana\`) and SDK calls fail with TLS connection-resets at api.axiom.co / api.grafana.net, while Sentry works fine — making it impossible to correlate signals across observability stacks from a sandbox.

## Test plan

- Verified the YAML is valid (matches existing entries' style and indentation).
- Hosts confirmed against vendor docs:
  - Axiom: https://axiom.co/docs/reference/cli (US + EU regions)
  - Grafana Cloud: https://grafana.com (account / stacks at *.grafana.net)