### PR TITLE
Add NuGet (.NET) package registry to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -402,3 +402,12 @@ shortcut:
 usaspending:
   - api.usaspending.gov
   - files.usaspending.gov
+
+# NuGet (.NET package registry — required for `dotnet add package`,
+# `dotnet restore`, and `nuget.exe`). The v3 service index lives at
+# api.nuget.org but lists search endpoints under
+# azuresearch-{usnc,ussc}.nuget.org and the gallery web UI under
+# www.nuget.org, so the *.nuget.org wildcard is needed to cover them all.
+nuget:
+  - api.nuget.org
+  - "*.nuget.org"


### PR DESCRIPTION
## Summary

Adds a `nuget:` section to `whitelist.yaml` so sandboxes can run `dotnet add package`, `dotnet restore`, and `nuget.exe` against the NuGet v3 API.

## Domains added

- `api.nuget.org` — v3 service index, package metadata, package binary downloads (PackageBaseAddress)
- `*.nuget.org` — wildcard for the sibling hosts the v3 index points at: `azuresearch-usnc.nuget.org`, `azuresearch-ussc.nuget.org` (search), and `www.nuget.org` (gallery). Per the file header, Daytona wildcards match exactly one subdomain level, so this covers all current and likely future `<x>.nuget.org` hosts without being overly broad.

## Why

Every .NET workflow currently fails inside Daytona sandboxes with `Connection reset by peer` during the TLS Client hello to `api.nuget.org`. NuGet is the only mainstream package manager not on the list — npm, PyPI, Maven, RubyGems, crates.io, Go modules, Composer, conda, Yarn, and bun already have sections.

Concretely, `dotnet add package Microsoft.AspNetCore.SignalR.Client` (or any other package) returns:

\`\`\`
error: Unable to load the service index for source https://api.nuget.org/v3/index.json.
error:   The SSL connection could not be established, see inner exception.
error:   Connection reset by peer
\`\`\`

This blocks any agent doing greenfield .NET work in a Daytona sandbox, where the standard pattern is `dotnet new <template>` followed by `dotnet add package` to pull dependencies.

## Verification of upstream hostnames

```
$ curl -s https://api.nuget.org/v3/index.json | jq -r '.resources[]."@id" | capture("//(?<h>[^/]+)").h' | sort -u
api.nuget.org
azuresearch-usnc.nuget.org
azuresearch-ussc.nuget.org
www.nuget.org
```

All four are covered by `api.nuget.org` + `*.nuget.org`.

## Related

- Supersedes #101 (same intent, but #101 only adds `api.nuget.org` which leaves search broken).
- Closes #100.

## Format

Follows the conventions of the recently-merged PRs (e.g. #95 `api.x.ai`, #87 GCP, #89 Cloudflare Tunnel): group header comment, section name, list of domains, no trailing whitespace.