### PR TITLE
add(whitelist): logo dev for company logos

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -396,3 +396,8 @@ shortcut:
 usaspending:
   - api.usaspending.gov
   - files.usaspending.gov
+
+# Logo Dev (API for Company Logos)
+logodev:
+  - img.logo.dev
+  - logo.dev


### PR DESCRIPTION
Logo Dev is a provider of company logos. Added the img.logo.dev endpoint and the base