### PR TITLE
Add Composio domains to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -391,7 +391,12 @@ rubygems:
 shortcut:
   - api.app.shortcut.com
   - app.shortcut.com
-  
+
+# Composio (agentic tool integration platform + MCP)
+composio:
+  - "*.composio.dev"
+  - composio.dev
+
 # USAspending.gov (federal spending data API + bulk downloads)
 usaspending:
   - api.usaspending.gov


### PR DESCRIPTION
Composio (composio.dev) is an agentic tool integration platform that exposes third-party SaaS tools (Gmail, Slack, GitHub, Jira, etc.) as MCP servers consumable by the Claude Agent SDK, OpenAI SDK, and similar.

Whitelisting `*.composio.dev` unblocks sandboxes that need to reach the Composio API (`backend.composio.dev`), OAuth link redirects (`connect.composio.dev`), and any future subdomains.