### PR TITLE
Add CommandCode AI CLI platform to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -164,6 +164,11 @@ ai_services:
   - api.x.ai
   - zenmux.ai
 
+# CommandCode (AI-powered CLI platform)
+commandcode:
+  - commandcode.ai
+  - "*.commandcode.ai"
+
 # Hugging Face (Model Hub + Datasets + Inference API)
 huggingface:
   - huggingface.co


### PR DESCRIPTION
This PR adds CommandCode (commandcode.ai) to the sandbox network whitelist.

**Added domains:**
- commandcode.ai
- *.commandcode.ai

**About CommandCode:**
CommandCode is an AI-powered CLI platform for autonomous coding agents. Users running Daytona sandboxes with CommandCode's CLI tools need access to these domains for authentication and API calls.

Thanks for maintaining this whitelist!