### PR TITLE
Add Oban Pro registry to Elixir whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -392,6 +392,7 @@ nuget:
 elixir:
   - hex.pm
   - "*.hex.pm"
+  - repo.oban.pro
 
 # RubyGems (Ruby gem metadata + gem tarball CDN)
 rubygems:


### PR DESCRIPTION
## Summary

Add `repo.oban.pro` to the Elixir/Erlang package registry allowlist.

## Why

The whitelist already includes Hex (`hex.pm`, `*.hex.pm`), which covers the public Elixir/Erlang package registry. Oban Pro is distributed through a private Hex-compatible package repository at `repo.oban.pro`, documented in Oban’s official installation guide:

https://oban.pro/docs/pro/installation.html

Oban is a widely used background job processing library in the Elixir/Phoenix ecosystem, and Oban Pro is a common commercial extension used by Elixir teams. Allowlisting this host lets Elixir projects fetch package dependencies in restricted-tier sandboxes without requiring broader network access.

## Domains

- `repo.oban.pro`