### PR TITLE
Add Nix cache domains to sandbox whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -26,6 +26,12 @@ bun:
   - bun.sh
   - "*.bun.sh"
 
+# Nix Package Manager and Binary Cache
+nix:
+  - cache.nixos.org
+  - channels.nixos.org
+  - releases.nixos.org
+
 # Git Hosting and Version Control
 github:
   - github.com


### PR DESCRIPTION
## Summary

Add official Nix package manager/cache domains to the sandbox whitelist.

## Domains

- cache.nixos.org
- channels.nixos.org
- releases.nixos.org

## Context

Nix dev shells need cache.nixos.org for binary substituter metadata and artifacts. Daytona sandboxes can reach GitHub and npm, but Nix startup fails when cache.nixos.org narinfo requests are reset.