### PR TITLE
Add Mesa base domain and BuildKite domains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -380,8 +380,15 @@ shopify:
   - "*.shopify.dev"
   - "*.shopifycdn.com"
 
+# Mesa (Versioned Virtual Filesystem)
 mesa:
+  - mesa.dev
   - "*.mesa.dev"
+
+# Buildkite (CI/CD)
+buildkite:
+  - buildkite.com
+  - "*.buildkite.com"
 
 # NuGet (.NET Package Manager)
 nuget:


### PR DESCRIPTION
Mesa is listed in the [Daytona docs](https://www.daytona.io/docs/en/mount-external-storage/#mount-a-mesafs-filesystem) as an external storage provider, but our install script (`curl -fsSL https://mesa.dev/install.sh | sh`) cannot be run because only `*.mesa.dev` is whitelisted, not `mesa.dev`.

In addition, the artifacts downloaded by the install script live in a BuildKite public registry, so this change also whitelists BuildKite (popular CI/CD platform).