### PR TITLE
Add Huggingface download CDN and Xet domains

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -168,6 +168,12 @@ ai_services:
 huggingface:
   - huggingface.co
   - "*.huggingface.co"
+  - hf.co
+  - "*.hf.co"
+  - "*.xethub.hf.co"
+  - "*.cdn.hf.co"
+  - "*.aws.cdn.hf.co"
+  - "*.gcp.cdn.hf.co"
 
 # Docker Registries and Container Services
 docker_registries:


### PR DESCRIPTION
Huggingface downloads nowadays redirect off `huggingface.co` to backends the current whitelist doesn't cover:
- the `hf.co` LFS CDN,
- Xet storage (`*.xethub.hf.co`),
- and the multi-cloud CDN (`*.cdn.hf.co`, `*.aws.cdn.hf.co`, `*.gcp.cdn.hf.co`).

Adding these to enable downloads from HF.