### PR TITLE
Add Slack domains to sandbox network whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -262,6 +262,8 @@ heroku:
 # Messaging Platforms
 messaging_services:
   - api.telegram.org
+  - slack.com
+  - "*.slack.com"
   - web.whatsapp.com
   - "*.whatsapp.net"
 


### PR DESCRIPTION
Adds Slack domains needed by Slack API and the hosted Slack MCP server.\n\nObserved from Daytona shared EU sandboxes:\n- curl to https://slack.com/api/api.test fails during TLS with connection reset by peer.\n- curl to https://mcp.slack.com/mcp fails during TLS with connection reset by peer.\n- the same mcp.slack.com request from a local machine reaches Slack and returns the expected 401 missing_token response.\n\nThis enables Slack MCP-based agents running inside Daytona sandboxes to reach Slack via slack.com and mcp.slack.com.