### PR TITLE
Add Browserbase to whitelist (cloud browser infra for AI agents)

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -438,3 +438,12 @@ kiro:
   - "*.kiro.dev"                  # cli.kiro.dev (install script)
   - "*.us-east-1.kiro.dev"        # runtime + management (chat)
   - prod.download.cli.kiro.dev    # install binary (3 labels - explicit)
+
+# Browserbase (cloud browser infrastructure for AI agents — Verified browsers, CDP connect)
+browserbase:
+  - browserbase.com
+  - "*.browserbase.com"
+  - connect.usw2.browserbase.com
+  - connect.use1.browserbase.com
+  - connect.euc1.browserbase.com
+  - connect.apse1.browserbase.com


### PR DESCRIPTION
### What

Adds **Browserbase** to the Envoy domain whitelist.

```yaml
browserbase:
  - browserbase.com
  - "*.browserbase.com"
  - connect.usw2.browserbase.com
  - connect.use1.browserbase.com
  - connect.euc1.browserbase.com
  - connect.apse1.browserbase.com
```

### Why

[Browserbase](https://browserbase.com) is cloud browser infrastructure for AI agents — the same category as the AI providers already in `ai_services`. Agents running inside Daytona sandboxes use the `browse` CLI / Browserbase SDK to drive a **remote** Verified browser over CDP (the browser runs on Browserbase, not in the sandbox), which is the reliable way to reach the real web from a sandbox: residential IP, anti-bot stealth, server-side CAPTCHA solving.

Today a Daytona sandbox TCP-connects to Browserbase's IPs but the TLS handshake is reset by the Envoy SNI filter because the domain isn't allowlisted, so `browse` cannot create a session. This entry unblocks it.

### Notes

- `*.browserbase.com` covers `api.browserbase.com` and `connect.browserbase.com` (one label). The region-specific `connect.<region>.browserbase.com` hosts are listed explicitly because wildcards match only one subdomain level.
- All hosts verified to resolve (AWS-backed; the connect endpoints are region ELBs).