### PR TITLE
Add TensorX (EU inference provider) to whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -153,6 +153,7 @@ ai_services:
   - aider.chat
   - api.letta.com
   - api.fireworks.ai
+  - api.tensorx.ai
   - open.bigmodel.cn
   - "*.z.ai"
   - "*.moonshot.ai"


### PR DESCRIPTION
## What

Adds `api.tensorx.ai` to the `ai_services` section.

## Why

[TensorX](https://tensorx.ai) is an EU-based inference provider (EU sovereign hosting) serving open models such as GLM, Kimi, MiniMax, and DeepSeek through OpenAI- and Anthropic-compatible APIs at `api.tensorx.ai`. It is a documented backend for coding agents like Claude Code via `ANTHROPIC_BASE_URL` ([docs](https://docs.tensorx.ai/)).

Agents running inside Daytona sandboxes currently cannot reach it — DNS and TCP succeed, but the TLS handshake is reset by the egress proxy:

```
* Connected to api.tensorx.ai (52.48.137.177) port 443
* OpenSSL SSL_connect: Connection reset by peer in connection to api.tensorx.ai:443
```

Comparable inference providers (`*.z.ai`, `api.fireworks.ai`, `*.moonshot.ai`, `*.minimax.io`, `api.featherless.ai`) are already whitelisted.

Only the API host is requested, not the full domain.
