### PR TITLE
Update whitelist.yaml with nvidia Ai services

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -172,6 +172,17 @@ ai_services:
   - "*.copass.id"
   - zenmux.ai
   - "*.devin.ai"
+  - "*.nvidia.com"
+  - "*.api.nvidia.com"
+  - "*.nvcf.nvidia.com"
+  - "*.ngc.nvidia.com"
+  - integrate.api.nvidia.com
+  - api.nvcf.nvidia.com
+  - assets.nvcf.nvidia.com
+  - registry.ngc.nvidia.com
+
+
+
 
 # Hugging Face (Model Hub + Datasets + Inference API)
 huggingface:

--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -181,9 +181,6 @@ ai_services:
   - assets.nvcf.nvidia.com
   - registry.ngc.nvidia.com
 
-
-
-
 # Hugging Face (Model Hub + Datasets + Inference API)
 huggingface:
   - huggingface.co


### PR DESCRIPTION
Nvidia NIM is a great alternative to openrouteur for bigger models and could be used to directly run ai projects or make them work directly inside one sandbox.