### PR TITLE
Add Terminal-Bench 2.1 domains (pytorch, povray, rcsb, pubchem, fpbase)

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -450,3 +450,27 @@ browserbase:
   - connect.use1.browserbase.com
   - connect.euc1.browserbase.com
   - connect.apse1.browserbase.com
+
+# Terminal-Bench 2.1 (scientific / ML downloads + bioinformatics APIs)
+# Needed by harbor terminal-bench/terminal-bench-2-1 tasks:
+#   pytorch-model-cli / pytorch-model-recovery → download.pytorch.org
+#   build-pov-ray → www.povray.org
+#   protein-assembly → data/search.rcsb.org, pubchem, fpbase
+pytorch:
+  - pytorch.org
+  - "*.pytorch.org"
+
+povray:
+  - povray.org
+  - "*.povray.org"
+
+rcsb:
+  - rcsb.org
+  - "*.rcsb.org"
+
+pubchem:
+  - pubchem.ncbi.nlm.nih.gov
+
+fpbase:
+  - fpbase.org
+  - "*.fpbase.org"


### PR DESCRIPTION
## Summary
- Adds domains required by [Terminal-Bench 2.1](https://www.tbench.ai/docs/run-terminal-bench-2-1) (`terminal-bench/terminal-bench-2-1`) when run on Daytona with the shared Envoy allowlist.
- Covers the hosts actually used by task solutions (not just apex URLs):
  - `pytorch.org` + `*.pytorch.org` → `download.pytorch.org` (`pytorch-model-cli`, `pytorch-model-recovery`)
  - `povray.org` + `*.povray.org` → `www.povray.org` (`build-pov-ray`)
  - `rcsb.org` + `*.rcsb.org` → `data.rcsb.org` / `search.rcsb.org` (`protein-assembly` via `rcsb-api`)
  - `pubchem.ncbi.nlm.nih.gov` + `fpbase.org` / `*.fpbase.org` → remaining `protein-assembly` APIs
