### PR TITLE
fixes a typo and adds a wildcard domain for you.com

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -486,7 +486,8 @@ fpbase:
 you:
   - you.com
   - "*.you.com"
-  - ydc-index-.io
+  - ydc-index.io
+  - *.ydc-index.io
 # Mountpoint for Amazon S3 (installer .deb + virtual-hosted bucket endpoints)
 # s3.amazonaws.com hosts the mount-s3.deb used by the S3, R2, Tigris, and
 # Supabase mount guides (runtime install AND snapshot builds).


### PR DESCRIPTION
Fixes the typo in `ydc-index-.io` and adds the wildcard `*.ydc-index.io`