### PR TITLE
Add GitHub Copilot API domains to sandbox whitelist

### DIFF
--- a/whitelist.yaml
+++ b/whitelist.yaml
@@ -177,6 +177,9 @@ ai_services:
   - api.aihubmix.com
   - "*.devin.ai"
   - "*.codeium.com"
+  - githubcopilot.com # GitHub Copilot CLI / agent API (not covered by *.github.com)
+  - "*.githubcopilot.com"
+  - "*.individual.githubcopilot.com" # api.individual.githubcopilot.com — two levels; *.githubcopilot.com only matches one
 
 # Hugging Face (Model Hub + Datasets + Inference API)
 huggingface:


### PR DESCRIPTION
## Summary
- Allow GitHub Copilot CLI / agent API hosts on the shared Envoy allowlist (restricted-tier egress).
- Adds `githubcopilot.com`, `*.githubcopilot.com`, and `*.individual.githubcopilot.com`.
- Needed because `*.github.com` does **not** cover `githubcopilot.com`, and wildcards only match one subdomain level (`api.individual.githubcopilot.com` requires the two-level entry).

## Test plan
- [ ] Confirm YAML parses / CI on this repo passes
- [ ] On a restricted-tier sandbox, verify TLS to `api.githubcopilot.com` and `api.individual.githubcopilot.com` succeeds after allowlist deploy
- [ ] Smoke-check GitHub Copilot CLI auth + a simple agent request from a Daytona sandbox